### PR TITLE
added @stub directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ src/editor/main.js
 src/editor/main.js.map
 src/editor/main.css
 src/editor/main.css.map
+
+#intelliJ bs
+.idea

--- a/src/default-schema.graphql
+++ b/src/default-schema.graphql
@@ -13,7 +13,7 @@
 
 type Company {
   id: ID
-  name: String @fake(type: companyName)
+  name: String @stub(value: "This is a stubbed name")
   industry: String
     @examples(values: ["IT", "Manufacturing", "Medicine", "Media"])
   employees: [Employee!] @listLength(min: 5, max: 10)

--- a/src/fake_definition.ts
+++ b/src/fake_definition.ts
@@ -220,6 +220,9 @@ const fakeDefinitionAST = parse(/* GraphQL */ `
 
   scalar examples__JSON
   directive @examples(values: [examples__JSON]!) on FIELD_DEFINITION | SCALAR
+  
+  scalar stub__JSON
+  directive @stub(value: stub__JSON!) on FIELD_DEFINITION | SCALAR
 `);
 
 function defToName(defNode) {

--- a/src/fake_schema.ts
+++ b/src/fake_schema.ts
@@ -34,9 +34,13 @@ type ListLengthArgs = {
   min: number;
   max: number;
 };
+type StubArgs = {
+  value: [any];
+};
 type DirectiveArgs = {
   fake?: FakeArgs;
   examples?: ExamplesArgs;
+  stub?: StubArgs;
   listLength?: ListLengthArgs;
 };
 
@@ -111,7 +115,9 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
       getExampleValueCB(fieldDef) ||
       getFakeValueCB(fieldDef) ||
       getExampleValueCB(type) ||
-      getFakeValueCB(type);
+      getFakeValueCB(type) ||
+      getStubValueCB(fieldDef) ||
+      getStubValueCB(type);
 
     if (isLeafType(type)) {
       if (valueCB) {
@@ -141,6 +147,12 @@ export const fakeFieldResolver: GraphQLFieldResolver<unknown, unknown> = async (
     const examplesDirective = schema.getDirective('examples');
     const args = getDirectiveArgs(examplesDirective, object) as ExamplesArgs;
     return args && (() => getRandomItem(args.values));
+  }
+
+  function getStubValueCB(object) {
+    const stubDirective = schema.getDirective('stub');
+    const args = getDirectiveArgs(stubDirective, object) as StubArgs;
+    return args && (() => args.value);
   }
 
   function getListLength(object) {


### PR DESCRIPTION
Added a new directive `@stub`, which accepts a single parameter `value`, and will use that value when mocking a graphql response. This is useful if you don't want random data, or repeated data (which is a downside of the current `@examples` directive)

